### PR TITLE
feat: スマートフォン対応のレスポンシブデザインを実装

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,9 @@ body {
   image-rendering: -webkit-crisp-edges;
   image-rendering: pixelated;
   image-rendering: crisp-edges;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+  overflow-x: hidden;
 }
 
 /* NES.cssのデフォルト文字色を上書きして白色を強制適用 */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link

--- a/src/components/StartScreen.module.scss
+++ b/src/components/StartScreen.module.scss
@@ -11,28 +11,38 @@
   background-color: #000;
   z-index: 9999;
   transition: opacity 0.5s;
+  padding: 1rem;
 
   font-family: "Press Start 2P", cursive;
   cursor: pointer;
 }
 
 .title {
-  font-size: 1.5rem; /* Tailwind の text-2xl */
+  font-size: 1rem;
   text-align: center;
   margin-bottom: 2rem;
+  line-height: 1.5;
+
+  @media (min-width: 480px) {
+    font-size: 1.5rem;
+  }
 
   @media (min-width: 640px) {
-    font-size: 2.25rem; /* sm:text-4xl */
+    font-size: 2.25rem;
   }
 }
 
 .subtitle {
-  font-size: 1.125rem; /* Tailwind の text-lg */
+  font-size: 0.75rem;
   text-align: center;
   animation: pulse 2s infinite;
 
+  @media (min-width: 480px) {
+    font-size: 1.125rem;
+  }
+
   @media (min-width: 640px) {
-    font-size: 1.25rem; /* sm:text-xl */
+    font-size: 1.25rem;
   }
 }
 

--- a/src/features/avatar/index.tsx
+++ b/src/features/avatar/index.tsx
@@ -26,7 +26,7 @@ export default function PixelAvatar({ isTyping = false }: PixelAvatarProps) {
   const imageSrc = currentImage === 0 ? "/images/avatar.png" : "/images/avatar_2.png";
 
   return (
-    <div className="w-60 h-60  p-1">
+    <div className="w-32 h-32 sm:w-48 sm:h-48 md:w-60 md:h-60 p-1">
       <Image
         src={imageSrc}
         alt="Pixel Art Avatar"

--- a/src/features/header/GameHeader.module.scss
+++ b/src/features/header/GameHeader.module.scss
@@ -1,9 +1,16 @@
 .header {
   border: 4px solid #fff;
-  padding: 1rem;
+  padding: 0.5rem;
   background-color: var(--background);
   position: relative;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+
+  @media (min-width: 640px) {
+    padding: 1rem;
+    margin-bottom: 1rem;
+    font-size: 1rem;
+  }
 
   &::before {
     content: "";
@@ -31,10 +38,11 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
   position: relative;
 
   @media (min-width: 640px) {
+    gap: 1rem;
     flex-direction: row;
     justify-content: space-between;
   }
@@ -50,9 +58,11 @@
 
 .statsSection {
   width: 100%;
+  max-width: 300px;
 
   @media (min-width: 640px) {
     width: 33.333333%;
+    max-width: none;
   }
 }
 
@@ -93,11 +103,13 @@
 
 .settingsSection {
   position: absolute;
-  top: 0;
+  top: -8px;
   right: 0;
+  z-index: 10;
 
   @media (min-width: 640px) {
     position: relative;
+    top: 0;
     display: flex;
     align-items: center;
   }

--- a/src/features/home/home.module.scss
+++ b/src/features/home/home.module.scss
@@ -1,26 +1,40 @@
 .gameContainer {
   width: 100%;
   max-width: 1200px;
-  height: 110vh;
+  min-height: 100vh;
   border: 4px solid #fff;
-  padding: 16px;
+  padding: 8px;
   background-color: var(--background);
   display: flex;
   flex-direction: column;
   margin: 0 auto;
+  box-sizing: border-box;
+
+  @media (min-width: 640px) {
+    padding: 16px;
+    height: 110vh;
+  }
 }
 
 .panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+
+  @media (min-width: 640px) {
+    gap: 1rem;
+  }
 
   .window {
     flex-grow: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1rem; /* p-4 */
+    padding: 0.5rem;
+
+    @media (min-width: 640px) {
+      padding: 1rem;
+    }
   }
 }
 
@@ -28,4 +42,9 @@
   overflow: hidden;
   padding: 4px;
   flex: 1;
+  min-height: 200px;
+
+  @media (min-width: 640px) {
+    min-height: auto;
+  }
 }

--- a/src/features/menu/menu.module.scss
+++ b/src/features/menu/menu.module.scss
@@ -1,9 +1,13 @@
 // メニューウィンドウのスタイル
 .container {
   border: 4px solid #fff;
-  padding: 1rem;
+  padding: 0.5rem;
   background-color: var(--background);
   position: relative;
+
+  @media (min-width: 640px) {
+    padding: 1rem;
+  }
 
   // Top corners
   &::before {
@@ -59,10 +63,16 @@
 // メニューグリッド
 .menuGrid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
   gap: 0.5rem;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(2, 1fr);
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+  }
 }
 
 // メニューアイテム
@@ -70,7 +80,11 @@
   cursor: pointer;
   position: relative;
   padding-left: 1.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
   transition: color 0.2s;
+  white-space: normal;
+  word-break: break-word;
 
   &:hover {
     color: var(--accent);

--- a/src/features/message/MessageWindow.module.scss
+++ b/src/features/message/MessageWindow.module.scss
@@ -1,11 +1,15 @@
 .container {
   border: 4px solid #fff;
-  padding: 1rem;
+  padding: 0.5rem;
   background-color: var(--background);
   position: relative;
   display: flex;
   flex-direction: column;
   flex: 1;
+
+  @media (min-width: 640px) {
+    padding: 1rem;
+  }
 
   // Window corner decorations (inside container)
   &::before {
@@ -64,8 +68,13 @@
 }
 
 .text {
-  font-size: 1.125rem; // text-lg
-  line-height: 1.625; // leading-relaxed
+  font-size: 0.875rem;
+  line-height: 1.5;
+
+  @media (min-width: 640px) {
+    font-size: 1.125rem;
+    line-height: 1.625;
+  }
 }
 
 .cursor {
@@ -79,8 +88,12 @@
 
 .arrow {
   text-align: right;
-  font-size: 1.5rem; // text-2xl
+  font-size: 1rem;
   animation: bounce 1s infinite;
+
+  @media (min-width: 640px) {
+    font-size: 1.5rem;
+  }
 }
 
 @keyframes blink {


### PR DESCRIPTION
- viewportメタタグを追加して適切なモバイル表示を設定
- 各コンポーネントのパディングとフォントサイズをモバイル用に調整
- メニューグリッドを1列表示に変更（モバイル時）
- アバター画像のサイズをレスポンシブに対応
- ヘッダーのレイアウトを縦並びに変更（モバイル時）
- メッセージウィンドウのテキストサイズを最適化
- 全体的なレイアウトを柔軟な高さに変更

close #9 